### PR TITLE
Ghc 7.8.4

### DIFF
--- a/library/GraphDB/Macros/Templates.hs
+++ b/library/GraphDB/Macros/Templates.hs
@@ -43,7 +43,7 @@ renderSetupInstance (setup, indexes, values, indexesFunctionClauses) =
     []
     (AppT (ConT ''G.Setup) (setup))
     [
-      TySynInstD ''G.Algorithm [setup] (ConT ''G.Linear),
+      TySynInstD ''G.Algorithm (TySynEqn [setup] (ConT ''G.Linear)),
       renderSumData ''G.Index setup IsStrict indexes,
       renderSumData ''G.Value setup NotStrict values,
       FunD 'G.indexes (map renderIndexesClause indexesFunctionClauses)

--- a/library/GraphDB/Util/Prelude.hs
+++ b/library/GraphDB/Util/Prelude.hs
@@ -28,10 +28,10 @@ import Control.Applicative as Exports
 import Control.Arrow as Exports hiding (left, right)
 import Control.Category as Exports
 import Data.Monoid as Exports
-import Data.Foldable as Exports
+import Data.Foldable as Exports hiding (toList)
 import Data.Traversable as Exports hiding (for)
 import Data.Maybe as Exports
-import Data.Either as Exports
+import Data.Either as Exports hiding (isLeft, isRight)
 import Data.List as Exports hiding (concat, foldr, foldl1, maximum, minimum, product, sum, all, and, any, concatMap, elem, foldl, foldr1, notElem, or, find, maximumBy, minimumBy, mapAccumL, mapAccumR, foldl')
 import Data.Tuple as Exports
 import Data.Ord as Exports (Down(..))
@@ -41,7 +41,7 @@ import Data.Word as Exports
 import Data.Ratio as Exports
 import Data.Fixed as Exports
 import Data.Ix as Exports
-import Data.Data as Exports
+import Data.Data as Exports hiding (Proxy)
 import Text.Read as Exports (readMaybe, readEither)
 import Control.Exception as Exports hiding (tryJust, assert)
 import Control.Concurrent as Exports hiding (yield)


### PR DESCRIPTION
Hi there, looks like it now compiles! Except for the test suite which fails for ```QuickCheck-GenT-0.1.3``` with the following error message:

```
Failed to install QuickCheck-GenT-0.1.3
Last 10 lines of the build log ( /Users/jun/dev/metasphere/graph-db/.cabal-sandbox/logs/QuickCheck-GenT-0.1.3.log ):
                             defined at src/QuickCheck/GenT/Prelude.hs:55:1
                          or ‘Exports.traceM’,
                             imported from ‘Debug.Trace’ at src/QuickCheck/GenT/Prelude.hs:41:1-29

src/QuickCheck/GenT/Prelude.hs:4:5:
    Conflicting exports for ‘traceM’:
       ‘module Exports’ exports ‘Exports.traceM’
         imported from ‘Debug.Trace’ at src/QuickCheck/GenT/Prelude.hs:41:1-29
       ‘traceM’ exports ‘QuickCheck.GenT.Prelude.traceM’
         defined at src/QuickCheck/GenT/Prelude.hs:55:1
```

Link to nikita-volkov/graph-db#3